### PR TITLE
Fix library typechecking errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"@eslint/js": "^8.56.0",
-				"@stylistic/eslint-plugin": "^1.6.1",
+				"@stylistic/eslint-plugin": "^1.6.3",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"@typescript-eslint/parser": "^6.21.0",
 				"eslint-plugin-react": "^7.33.2",
@@ -192,14 +192,15 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.6.1.tgz",
-			"integrity": "sha512-De7Sw86OtIf7SsMgjLCf4bTeI3085Plyh4l0Rg1V42BTFo/Q6Pz7Cbu31rEk/UHFiEna/YO8Hxj80jFP3ObrQw==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.6.3.tgz",
+			"integrity": "sha512-WDa4FjhImp7YcztRaMG09svhKYYhi2Hc4p9ltQRSqyB4fsUUFm+GKzStqqH7xfjHnxacMJaOnaMGRTUqIIZDLA==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.6.1",
-				"@stylistic/eslint-plugin-jsx": "1.6.1",
-				"@stylistic/eslint-plugin-plus": "1.6.1",
-				"@stylistic/eslint-plugin-ts": "1.6.1"
+				"@stylistic/eslint-plugin-js": "1.6.3",
+				"@stylistic/eslint-plugin-jsx": "1.6.3",
+				"@stylistic/eslint-plugin-plus": "1.6.3",
+				"@stylistic/eslint-plugin-ts": "1.6.3",
+				"@types/eslint": "^8.56.2"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -209,10 +210,11 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.6.1.tgz",
-			"integrity": "sha512-gHRxkbA5p8S1fnChE7Yf5NFltRZCzbCuQOcoTe93PSKBC4GqVjZmlWUSLz9pJKHvDAUTjWkfttWHIOaFYPEhRQ==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.6.3.tgz",
+			"integrity": "sha512-ckdz51oHxD2FaxgY2piJWJVJiwgp8Uu96s+as2yB3RMwavn3nHBrpliVukXY9S/DmMicPRB2+H8nBk23GDG+qA==",
 			"dependencies": {
+				"@types/eslint": "^8.56.2",
 				"acorn": "^8.11.3",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-visitor-keys": "^3.4.3",
@@ -226,13 +228,14 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.6.1.tgz",
-			"integrity": "sha512-uJQcg3iqrhm3EH15ZjxmZ1YmXXexkLKFEgxkWA3RYjgAVTx8k7xGJwClK/JnjKDGdbFRiDQPjxt964R1vsaFaQ==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.6.3.tgz",
+			"integrity": "sha512-SRysCIg59Zvn3dJPqHziiHwuni4NNj1et5stAmivmyQ3Cdp2ULCB7tGxCF1OxpkwRlZQue3ZgdiM7EXfJKaf9w==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "^1.6.1",
+				"@stylistic/eslint-plugin-js": "^1.6.3",
+				"@types/eslint": "^8.56.2",
 				"estraverse": "^5.3.0",
-				"picomatch": "^3.0.1"
+				"picomatch": "^4.0.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -242,23 +245,25 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-plus": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.6.1.tgz",
-			"integrity": "sha512-nYIXfdYN+pBVmm0vPCKQFg/IK35tf3ZGz+0WENUL6ww1+jKM6/i36FalRFculiHzO+wOpJ3/yXWJC3PCbwGFZQ==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.6.3.tgz",
+			"integrity": "sha512-TuwQOdyVGycDPw5XeF7W4f3ZonAVzOAzORSaD2yGAJ0fRAbJ+l/v3CkKzIAqBBwWkc+c2aRMsWtLP2+viBnmlQ==",
 			"dependencies": {
-				"@typescript-eslint/utils": "^6.20.0"
+				"@types/eslint": "^8.56.2",
+				"@typescript-eslint/utils": "^6.21.0"
 			},
 			"peerDependencies": {
 				"eslint": "*"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.6.1.tgz",
-			"integrity": "sha512-eZxrFaLhPJVUQmtsRXKiuzSou0nlHevKc1WsfhxUJ9p8juv3G3YlbbGeYg4AP1fNlEmWs/lZQAP2WfzQOdBNvQ==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.6.3.tgz",
+			"integrity": "sha512-v5GwZsPLblWM9uAIdaSi31Sed3XBWlTFQJ3b5upEmj6QsKYivA5nmIYutwqqL133QdVWjmC86pINlx2Muq3uNQ==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.6.1",
-				"@typescript-eslint/utils": "^6.20.0"
+				"@stylistic/eslint-plugin-js": "1.6.3",
+				"@types/eslint": "^8.56.2",
+				"@typescript-eslint/utils": "^6.21.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -271,7 +276,6 @@
 			"version": "8.56.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
 			"integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -289,8 +293,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -2312,11 +2315,11 @@
 			}
 		},
 		"node_modules/picomatch": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-			"integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+			"integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@eslint/js": "^8.56.0",
+				"@eslint/js": "^8.57.0",
 				"@stylistic/eslint-plugin": "^1.6.3",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"@typescript-eslint/parser": "^6.21.0",
 				"eslint-plugin-react": "^7.33.2",
 				"eslint-plugin-react-hooks": "^4.6.0",
-				"globals": "^13.24.0"
+				"globals": "^14.0.0"
 			},
 			"devDependencies": {
 				"@types/eslint__js": "^8.42.3",
-				"eslint": "^8.56.0",
+				"eslint": "^8.57.0",
 				"typescript": "^5.3.3"
 			},
 			"engines": {
@@ -90,6 +90,20 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -102,9 +116,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -981,15 +995,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.56.0",
-				"@humanwhocodes/config-array": "^0.11.13",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -1146,6 +1160,20 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
@@ -1448,14 +1476,11 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
 		"test": "echo \"No tests\""
 	},
 	"dependencies": {
-		"@eslint/js": "^8.56.0",
+		"@eslint/js": "^8.57.0",
 		"@stylistic/eslint-plugin": "^1.6.3",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"eslint-plugin-react": "^7.33.2",
 		"eslint-plugin-react-hooks": "^4.6.0",
-		"globals": "^13.24.0"
+		"globals": "^14.0.0"
 	},
 	"devDependencies": {
 		"@types/eslint__js": "^8.42.3",
-		"eslint": "^8.56.0",
+		"eslint": "^8.57.0",
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@eslint/js": "^8.56.0",
-		"@stylistic/eslint-plugin": "^1.6.1",
+		"@stylistic/eslint-plugin": "^1.6.3",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"eslint-plugin-react": "^7.33.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,5 @@
 
 		// For the globals package
 		"resolveJsonModule": true,
-
-		// Until @stylistic/eslint-plugin fixes its types
-		// Also means src/@types/* gets ignored, so comment this to test it
-		"skipLibCheck": true,
 	},
 }


### PR DESCRIPTION
### Changed

- Updated all dependencies (that wouldn't require major changes)

### Fixed

- #3 by updating `@stylistic/eslint-plugin`

### Removed

- `skipLibCheck` workaround for the bug above