### PR TITLE
Update to typescript-eslint v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A simple [ESLint](https://eslint.org/) configuration for JavaScript, [TypeScript](https://www.typescriptlang.org/), and [React](https://react.dev/) projects.
 
-Uses [@eslint/js](https://www.npmjs.com/package/@eslint/js), [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin), [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin), [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react), and [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) configurations.
+Uses [@eslint/js](https://www.npmjs.com/package/@eslint/js), [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin), [typescript-eslint](https://www.npmjs.com/package/typescript-eslint), [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react), and [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) configurations.
 
 Written in TypeScript and transpiles to JavaScript (ESM).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jstnmcbrd/eslint-config",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jstnmcbrd/eslint-config",
-			"version": "1.0.0",
+			"version": "1.0.1-alpha",
 			"license": "ISC",
 			"dependencies": {
 				"@eslint/js": "^8.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,10 @@
 			"dependencies": {
 				"@eslint/js": "^8.57.0",
 				"@stylistic/eslint-plugin": "^1.6.3",
-				"@typescript-eslint/eslint-plugin": "^6.21.0",
-				"@typescript-eslint/parser": "^6.21.0",
 				"eslint-plugin-react": "^7.33.2",
 				"eslint-plugin-react-hooks": "^4.6.0",
-				"globals": "^14.0.0"
+				"globals": "^14.0.0",
+				"typescript-eslint": "^7.1.0"
 			},
 			"devDependencies": {
 				"@types/eslint__js": "^8.42.3",
@@ -320,15 +319,15 @@
 			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.0.tgz",
+			"integrity": "sha512-j6vT/kCulhG5wBmGtstKeiVr1rdXE4nk+DT1k6trYkwlrvW9eOF5ZbgKnd/YR6PcM4uTEXa0h6Fcvf6X7Dxl0w==",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/type-utils": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/scope-manager": "7.1.0",
+				"@typescript-eslint/type-utils": "7.1.0",
+				"@typescript-eslint/utils": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -344,8 +343,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -353,15 +352,110 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz",
+			"integrity": "sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.0.tgz",
+			"integrity": "sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz",
+			"integrity": "sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.0.tgz",
+			"integrity": "sha512-WUFba6PZC5OCGEmbweGpnNJytJiLG7ZvDBJJoUcX4qZYf1mGZ97mO2Mps6O2efxJcJdRNpqweCistDbZMwIVHw==",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "7.1.0",
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/typescript-estree": "7.1.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz",
+			"integrity": "sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.0.tgz",
+			"integrity": "sha512-V1EknKUubZ1gWFjiOZhDSNToOjs63/9O0puCgGS8aDOgpZY326fzFu15QAUjwaXzRZjf/qdsdBrckYdv9YxB8w==",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "7.1.0",
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/typescript-estree": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -372,12 +466,83 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz",
+			"integrity": "sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.0.tgz",
+			"integrity": "sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz",
+			"integrity": "sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz",
+			"integrity": "sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
@@ -397,12 +562,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.0.tgz",
+			"integrity": "sha512-UZIhv8G+5b5skkcuhgvxYWHjk7FW7/JP5lPASMEUoliAPwIH/rxoUSQPia2cuOj9AmDZmwUl1usKm85t5VUMew==",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/typescript-estree": "7.1.0",
+				"@typescript-eslint/utils": "7.1.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -414,12 +579,107 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz",
+			"integrity": "sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.0.tgz",
+			"integrity": "sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz",
+			"integrity": "sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/visitor-keys": "7.1.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.0.tgz",
+			"integrity": "sha512-WUFba6PZC5OCGEmbweGpnNJytJiLG7ZvDBJJoUcX4qZYf1mGZ97mO2Mps6O2efxJcJdRNpqweCistDbZMwIVHw==",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "7.1.0",
+				"@typescript-eslint/types": "7.1.0",
+				"@typescript-eslint/typescript-estree": "7.1.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz",
+			"integrity": "sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==",
+			"dependencies": {
+				"@typescript-eslint/types": "7.1.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
@@ -2850,6 +3110,30 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.1.0.tgz",
+			"integrity": "sha512-GfAALH4zoqae5mIfHr7WU3BsULHP73hjwF8vCmyTkH3IXHXjqg3JNWwUcd8CwOTLIr4tjRTZQWpToyESPnpOhg==",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "7.1.0",
+				"@typescript-eslint/parser": "7.1.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,10 @@
 	"dependencies": {
 		"@eslint/js": "^8.57.0",
 		"@stylistic/eslint-plugin": "^1.6.3",
-		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@typescript-eslint/parser": "^6.21.0",
 		"eslint-plugin-react": "^7.33.2",
 		"eslint-plugin-react-hooks": "^4.6.0",
-		"globals": "^14.0.0"
+		"globals": "^14.0.0",
+		"typescript-eslint": "^7.1.0"
 	},
 	"devDependencies": {
 		"@types/eslint__js": "^8.42.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jstnmcbrd/eslint-config",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha",
 	"description": "Justin's ESLint configuration",
 	"keywords": [
 		"eslint",

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -23,12 +23,12 @@ export function typescript(): Linter.FlatConfig[] {
 			},
 			rules: {
 				// Recommended
+				...tsESLint.configs.eslintRecommended.rules,
 				...tsESLint.configs.strictTypeChecked[2]?.rules,
 				...tsESLint.configs.stylisticTypeChecked[2]?.rules,
 
 				// Overrides
 				'no-shadow': 0, // handled by TypeScript
-				'no-undef': 0, // handled by TypeScript
 			},
 		},
 	];

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,5 +1,4 @@
-import typescriptParser from '@typescript-eslint/parser';
-import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import tsESLint from 'typescript-eslint';
 import type { ESLint, Linter } from 'eslint';
 
 /** @returns ESLint configuration for TypeScript. */
@@ -12,20 +11,20 @@ export function typescript(): Linter.FlatConfig[] {
 		{
 			files: ['**/*.{m,c,}ts{x,}'],
 			plugins: {
-				'@typescript-eslint': typescriptPlugin as unknown as ESLint.Plugin,
+				'@typescript-eslint': tsESLint.plugin as ESLint.Plugin,
 			},
 			languageOptions: {
-				parser: typescriptParser as Linter.ParserModule,
+				parser: tsESLint.parser as Linter.ParserModule,
 				parserOptions: {
 					project: './tsconfig.eslint.json',
-					// TODO use this once @typescript-eslint hits v7 and it stops being experimental
+					// TODO use this once it stops being experimental
 					// EXPERIMENTAL_useProjectService: true,
 				},
 			},
 			rules: {
 				// Recommended
-				...typescriptPlugin.configs['strict-type-checked']?.rules,
-				...typescriptPlugin.configs['stylistic-type-checked']?.rules,
+				...tsESLint.configs.strictTypeChecked[2]?.rules,
+				...tsESLint.configs.stylisticTypeChecked[2]?.rules,
 
 				// Overrides
 				'no-shadow': 0, // handled by TypeScript


### PR DESCRIPTION
### Changed

- Replaced `@typescript-eslint/*` packages with new `typescript-eslint` package (see [here](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/#switching-to-typescript-eslint))
- `README` to reflect new package names
- TypeScript eslint config file to use new `typescript-eslint` package
- Package version to alpha version to reflect unpublished changes

### Removed

- `no-undef` disabled rule (already handled by `eslintRecommended` configuration)