### PR TITLE
Add more badges to README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Lint
-        run: npm run lint      
+        run: npm run lint
 
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # @jstnmcbrd/eslint-config
 
+[![Validate](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/eslint-config/validate.yml?logo=github&label=Validate)](https://github.com/JstnMcBrd/eslint-config/actions/workflows/validate.yml)
+<br />
 [![NPM Version](https://img.shields.io/npm/v/@jstnmcbrd/eslint-config)](https://www.npmjs.com/package/@jstnmcbrd/eslint-config)
+[![NPM License](https://img.shields.io/npm/l/@jstnmcbrd/eslint-config)](./LICENSE)
+![NPM Type Definitions](https://img.shields.io/npm/types/@jstnmcbrd/eslint-config)
+![NPM Downloads](https://img.shields.io/npm/dt/@jstnmcbrd/eslint-config)
+<br />
+![Node version](https://img.shields.io/node/v/@jstnmcbrd/eslint-config)
+[![ESLint version](https://img.shields.io/npm/dependency-version/@jstnmcbrd/eslint-config/peer/eslint)](https://www.npmjs.com/package/eslint)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @jstnmcbrd/eslint-config
 
-[![npm package](https://badge.fury.io/js/@jstnmcbrd%2Feslint-config.svg)](https://badge.fury.io/js/@jstnmcbrd%2Feslint-config)
+[![NPM Version](https://img.shields.io/npm/v/@jstnmcbrd/eslint-config)](https://www.npmjs.com/package/@jstnmcbrd/eslint-config)
 
 ## About
 


### PR DESCRIPTION
### Added

- Badge for Validate workflow status
- Badges for NPM license, type definitions, and downloads
- Badge for required Node and ESLint versions

### Changed

- `NPM version` badge to use [shields.io](https://shields.io/)

### Fixed

- Double-quote usage in `publish.yml`