### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,5 +31,6 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
+      # No tests
+      # - name: Test
+      #   run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"@eslint/js": "^8.57.0",
-				"@stylistic/eslint-plugin": "^1.7.0",
+				"@stylistic/eslint-plugin": "^2.1.0",
 				"eslint-plugin-react": "^7.34.1",
-				"eslint-plugin-react-hooks": "^4.6.0",
+				"eslint-plugin-react-hooks": "^4.6.2",
 				"globals": "^15.0.0",
-				"typescript-eslint": "^7.5.0"
+				"typescript-eslint": "^7.9.0"
 			},
 			"devDependencies": {
 				"@types/eslint__js": "^8.42.3",
 				"eslint": "^8.57.0",
-				"typescript": "^5.4.4"
+				"typescript": "^5.4.5"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=15.3.0"
@@ -205,90 +205,116 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.7.0.tgz",
-			"integrity": "sha512-ThMUjGIi/jeWYNvOdjZkoLw1EOVs0tEuKXDgWvTn8uWaEz55HuPlajKxjKLpv19C+qRDbKczJfzUODfCdME53A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.1.0.tgz",
+			"integrity": "sha512-cBBowKP2u/+uE5CzgH5w8pE9VKqcM7BXdIDPIbGt2rmLJGnA6MJPr9vYGaqgMoJFs7R/FzsMQerMvvEP40g2uw==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.7.0",
-				"@stylistic/eslint-plugin-jsx": "1.7.0",
-				"@stylistic/eslint-plugin-plus": "1.7.0",
-				"@stylistic/eslint-plugin-ts": "1.7.0",
-				"@types/eslint": "^8.56.2"
+				"@stylistic/eslint-plugin-js": "2.1.0",
+				"@stylistic/eslint-plugin-jsx": "2.1.0",
+				"@stylistic/eslint-plugin-plus": "2.1.0",
+				"@stylistic/eslint-plugin-ts": "2.1.0",
+				"@types/eslint": "^8.56.10"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.7.0.tgz",
-			"integrity": "sha512-PN6On/+or63FGnhhMKSQfYcWutRlzOiYlVdLM6yN7lquoBTqUJHYnl4TA4MHwiAt46X5gRxDr1+xPZ1lOLcL+Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
+			"integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
 			"dependencies": {
-				"@types/eslint": "^8.56.2",
+				"@types/eslint": "^8.56.10",
 				"acorn": "^8.11.3",
-				"escape-string-regexp": "^4.0.0",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1"
+				"eslint-visitor-keys": "^4.0.0",
+				"espree": "^10.0.1"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8.40.0"
 			}
 		},
-		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.7.0.tgz",
-			"integrity": "sha512-BACdBwXakQvjYIST5N2WWhRbvhRsIxa/F59BiZol+0IH4FSmDXhie7v/yaxDIIA9CbfElzOmIA5nWNYTVXcnwQ==",
+		"node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "^1.7.0",
-				"@types/eslint": "^8.56.2",
-				"estraverse": "^5.3.0",
-				"picomatch": "^4.0.1"
+				"acorn": "^8.11.3",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.0.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.1.0.tgz",
+			"integrity": "sha512-mMD7S+IndZo2vxmwpHVTCwx2O1VdtE5tmpeNwgaEcXODzWV1WTWpnsc/PECQKIr/mkLPFWiSIqcuYNhQ/3l6AQ==",
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "^2.1.0",
+				"@types/eslint": "^8.56.10",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-plus": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.7.0.tgz",
-			"integrity": "sha512-AabDw8sXsc70Ydx3qnbeTlRHZnIwY6UKEenBPURPhY3bfYWX+/pDpZH40HkOu94v8D0DUrocPkeeEUxl4e0JDg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.1.0.tgz",
+			"integrity": "sha512-S5QAlgYXESJaSBFhBSBLZy9o36gXrXQwWSt6QkO+F0SrT9vpV5JF/VKoh+ojO7tHzd8Ckmyouq02TT9Sv2B0zQ==",
 			"dependencies": {
-				"@types/eslint": "^8.56.2",
-				"@typescript-eslint/utils": "^6.21.0"
+				"@types/eslint": "^8.56.10",
+				"@typescript-eslint/utils": "^7.8.0"
 			},
 			"peerDependencies": {
 				"eslint": "*"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.7.0.tgz",
-			"integrity": "sha512-QsHv98mmW1xaucVYQTyLDgEpybPJ/6jPPxVBrIchntWWwj74xCWKUiw79hu+TpYj/Pbhd9rkqJYLNq3pQGYuyA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.1.0.tgz",
+			"integrity": "sha512-2ioFibufHYBALx2TBrU4KXovCkN8qCqcb9yIHc0fyOfTaO5jw4d56WW7YRcF3Zgde6qFyXwAN6z/+w4pnmos1g==",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.7.0",
-				"@types/eslint": "^8.56.2",
-				"@typescript-eslint/utils": "^6.21.0"
+				"@stylistic/eslint-plugin-js": "2.1.0",
+				"@types/eslint": "^8.56.10",
+				"@typescript-eslint/utils": "^7.8.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
-			"integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
+			"version": "8.56.10",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+			"integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -313,27 +339,20 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
 		},
-		"node_modules/@types/semver": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
-		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.5.0.tgz",
-			"integrity": "sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.9.0.tgz",
+			"integrity": "sha512-6e+X0X3sFe/G/54aC3jt0txuMTURqLyekmEHViqyA2VnxhLMpvA6nqmcjIy+Cr9tLDHPssA74BP5Mx9HQIxBEA==",
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/type-utils": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "7.9.0",
+				"@typescript-eslint/type-utils": "7.9.0",
+				"@typescript-eslint/utils": "7.9.0",
+				"@typescript-eslint/visitor-keys": "7.9.0",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
+				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -352,110 +371,15 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
-			"integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.9.0.tgz",
+			"integrity": "sha512-qHMJfkL5qvgQB2aLvhUSXxbK7OLnDkwPzFalg458pxQgfxKDfT1ZDbHQM/I6mDIf/svlMkj21kzKuQ2ixJlatQ==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
+				"@typescript-eslint/scope-manager": "7.9.0",
+				"@typescript-eslint/types": "7.9.0",
+				"@typescript-eslint/typescript-estree": "7.9.0",
+				"@typescript-eslint/visitor-keys": "7.9.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -474,87 +398,16 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.9.0.tgz",
+			"integrity": "sha512-ZwPK4DeCDxr3GJltRz5iZejPFAAr4Wk3+2WIBaj1L5PYK5RgxExu/Y68FFVclN0y6GGwH8q+KgKRCvaTmFBbgQ==",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
+				"@typescript-eslint/types": "7.9.0",
+				"@typescript-eslint/visitor-keys": "7.9.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -562,14 +415,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
-			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.9.0.tgz",
+			"integrity": "sha512-6Qy8dfut0PFrFRAZsGzuLoM4hre4gjzWJB6sUvdunCYZsYemTkzZNwF1rnGea326PHPT3zn5Lmg32M/xfJfByA==",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.9.0",
+				"@typescript-eslint/utils": "7.9.0",
 				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -585,109 +438,14 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+			"integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -695,21 +453,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz",
+			"integrity": "sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/types": "7.9.0",
+				"@typescript-eslint/visitor-keys": "7.9.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -722,39 +480,36 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.9.0.tgz",
+			"integrity": "sha512-5KVRQCzZajmT4Ep+NEgjXCvjuypVvYHUW7RHlXzNPuak2oWpVoD1jf5xCP0dPAuNIchjC7uQyvbdaSTFaLqSdA==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
+				"@typescript-eslint/scope-manager": "7.9.0",
+				"@typescript-eslint/types": "7.9.0",
+				"@typescript-eslint/typescript-estree": "7.9.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz",
+			"integrity": "sha512-iESPx2TNLDNGQLyjKhUvIKprlP49XNEK+MvIf9nIO7ZZaZdbnfWKHnXAgufpxqfA0YryH8XToi4+CjBgVnFTSQ==",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@typescript-eslint/types": "7.9.0",
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1446,9 +1201,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
 			"engines": {
 				"node": ">=10"
 			},
@@ -2472,17 +2227,6 @@
 				"loose-envify": "cli.js"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2515,9 +2259,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -2945,12 +2689,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -3259,9 +3000,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3271,13 +3012,13 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.5.0.tgz",
-			"integrity": "sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.9.0.tgz",
+			"integrity": "sha512-7iTn9c10teHHCys5Ud/yaJntXZrjt3h2mrx3feJGBOLgQkF3TB1X89Xs3aVQ/GgdXRAXpk2bPTdpRwHP4YkUow==",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "7.5.0",
-				"@typescript-eslint/parser": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0"
+				"@typescript-eslint/eslint-plugin": "7.9.0",
+				"@typescript-eslint/parser": "7.9.0",
+				"@typescript-eslint/utils": "7.9.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -3293,101 +3034,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -3505,11 +3151,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
 	],
 	"scripts": {
 		"build": "tsc",
-		"lint": "eslint .",
-		"test": "echo \"No tests\""
+		"lint": "eslint ."
 	},
 	"dependencies": {
 		"@eslint/js": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
 	},
 	"dependencies": {
 		"@eslint/js": "^8.57.0",
-		"@stylistic/eslint-plugin": "^1.7.0",
+		"@stylistic/eslint-plugin": "^2.1.0",
 		"eslint-plugin-react": "^7.34.1",
-		"eslint-plugin-react-hooks": "^4.6.0",
+		"eslint-plugin-react-hooks": "^4.6.2",
 		"globals": "^15.0.0",
-		"typescript-eslint": "^7.5.0"
+		"typescript-eslint": "^7.9.0"
 	},
 	"devDependencies": {
 		"@types/eslint__js": "^8.42.3",
 		"eslint": "^8.57.0",
-		"typescript": "^5.4.4"
+		"typescript": "^5.4.5"
 	},
 	"peerDependencies": {
 		"eslint": ">=8.21.0"


### PR DESCRIPTION
With eslint v9 released, many dependencies are working toward supporting it. In the meantime, it'd be good to download the latest pre-eslint v9 versions.

-----

### Changed

- All dependencies to latest versions (besides eslint v9)

### Removed

- Empty `test` npm script