### PR TITLE
Improve TypeScript config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-	"eslint.experimental.useFlatConfig": true,
+	"eslint.useFlatConfig": true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,17 @@
 			"license": "ISC",
 			"dependencies": {
 				"@eslint/js": "^8.57.0",
-				"@stylistic/eslint-plugin": "^2.2.1",
-				"eslint-plugin-react": "^7.34.1",
+				"@stylistic/eslint-plugin": "^2.3.0",
+				"eslint-plugin-react": "^7.35.0",
 				"eslint-plugin-react-hooks": "^4.6.2",
-				"globals": "^15.6.0",
-				"typescript-eslint": "^7.13.1"
+				"globals": "^15.9.0",
+				"typescript-eslint": "^7.18.0"
 			},
 			"devDependencies": {
+				"@types/eslint": "^8.56.11",
 				"@types/eslint__js": "^8.42.3",
 				"eslint": "^8.57.0",
-				"typescript": "^5.5.3"
+				"typescript": "^5.5.4"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=15.3.0"
@@ -56,9 +57,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -166,6 +167,7 @@
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
@@ -215,6 +217,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -253,15 +256,15 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.2.1.tgz",
-			"integrity": "sha512-YErqfwWFbRCpkyPtrcVYaJhvEn9aXE4WzxxkZ7Q3OKS4QD9CE6qZjzEw5DhcA2wL3Jo6JbzSB3/stJMNocGMgQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
+			"integrity": "sha512-rtiz6u5gRyyEZp36FcF1/gHJbsbT3qAgXZ1qkad6Nr/xJ9wrSJkiSFFQhpYVTIZ7FJNRJurEcumZDCwN9dEI4g==",
 			"license": "MIT",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "2.2.1",
-				"@stylistic/eslint-plugin-jsx": "2.2.1",
-				"@stylistic/eslint-plugin-plus": "2.2.1",
-				"@stylistic/eslint-plugin-ts": "2.2.1",
+				"@stylistic/eslint-plugin-js": "2.3.0",
+				"@stylistic/eslint-plugin-jsx": "2.3.0",
+				"@stylistic/eslint-plugin-plus": "2.3.0",
+				"@stylistic/eslint-plugin-ts": "2.3.0",
 				"@types/eslint": "^8.56.10"
 			},
 			"engines": {
@@ -272,9 +275,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.2.1.tgz",
-			"integrity": "sha512-M2dQkKw2R4R+b1SJ/xElJ9bDVq/vCI31VpIIxkZD9KXCqbUHvtsGpZH3eO6MzmFWOZj4PfNdEQdP332MtqjCPg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.3.0.tgz",
+			"integrity": "sha512-lQwoiYb0Fs6Yc5QS3uT8+T9CPKK2Eoxc3H8EnYJgM26v/DgtW+1lvy2WNgyBflU+ThShZaHm3a6CdD9QeKx23w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint": "^8.56.10",
@@ -290,12 +293,12 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.2.1.tgz",
-			"integrity": "sha512-J/R4tU38v8gVqKPy6Mh22dq8btLSPWK06SuRc/ryOxT8LpW2ZdcSDP4HNvQiOte0Wy9xzgKJHP4JlYauDZ/oVw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.3.0.tgz",
+			"integrity": "sha512-tsQ0IEKB195H6X9A4iUSgLLLKBc8gUBWkBIU8tp1/3g2l8stu+PtMQVV/VmK1+3bem5FJCyvfcZIQ/WF1fsizA==",
 			"license": "MIT",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "^2.2.1",
+				"@stylistic/eslint-plugin-js": "^2.3.0",
 				"@types/eslint": "^8.56.10",
 				"estraverse": "^5.3.0",
 				"picomatch": "^4.0.2"
@@ -308,9 +311,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-plus": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.2.1.tgz",
-			"integrity": "sha512-VGdTcQzZ/cZNcJnvjDos1VLzUerPapvYCVSCQZEhupMtmxt+mbITiJWzLLHYNfqGBnW7ABqViLfob+s3Q2GcKw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.3.0.tgz",
+			"integrity": "sha512-xboPWGUU5yaPlR+WR57GwXEuY4PSlPqA0C3IdNA/+1o2MuBi95XgDJcZiJ9N+aXsqBXAPIpFFb+WQ7QEHo4f7g==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint": "^8.56.10",
@@ -321,12 +324,12 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.2.1.tgz",
-			"integrity": "sha512-2AbpXGGorCEzDryth7RhOMJWlko+sxSs1lxL2tSXB5H/EffmXgLn1tMoMKgwYJW3s6v0BxJRr5BWj9B9JaZTUQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.3.0.tgz",
+			"integrity": "sha512-wqOR38/uz/0XPnHX68ftp8sNMSAqnYGjovOTN7w00xnjS6Lxr3Sk7q6AaxWWqbMvOj7V2fQiMC5HWAbTruJsCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "2.2.1",
+				"@stylistic/eslint-plugin-js": "2.3.0",
 				"@types/eslint": "^8.56.10",
 				"@typescript-eslint/utils": "^7.12.0"
 			},
@@ -338,9 +341,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.10",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-			"integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+			"version": "8.56.11",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
+			"integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
@@ -370,16 +373,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
-			"integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+			"integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "7.13.1",
-				"@typescript-eslint/type-utils": "7.13.1",
-				"@typescript-eslint/utils": "7.13.1",
-				"@typescript-eslint/visitor-keys": "7.13.1",
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/type-utils": "7.18.0",
+				"@typescript-eslint/utils": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -403,15 +406,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
-			"integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+			"integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.13.1",
-				"@typescript-eslint/types": "7.13.1",
-				"@typescript-eslint/typescript-estree": "7.13.1",
-				"@typescript-eslint/visitor-keys": "7.13.1",
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/typescript-estree": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -431,13 +434,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
-			"integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+			"integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "7.13.1",
-				"@typescript-eslint/visitor-keys": "7.13.1"
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -448,13 +451,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
-			"integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+			"integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.13.1",
-				"@typescript-eslint/utils": "7.13.1",
+				"@typescript-eslint/typescript-estree": "7.18.0",
+				"@typescript-eslint/utils": "7.18.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -475,9 +478,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
-			"integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+			"integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -488,13 +491,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
-			"integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+			"integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "7.13.1",
-				"@typescript-eslint/visitor-keys": "7.13.1",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/visitor-keys": "7.18.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -516,15 +519,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
-			"integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+			"integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "7.13.1",
-				"@typescript-eslint/types": "7.13.1",
-				"@typescript-eslint/typescript-estree": "7.13.1"
+				"@typescript-eslint/scope-manager": "7.18.0",
+				"@typescript-eslint/types": "7.18.0",
+				"@typescript-eslint/typescript-estree": "7.18.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -538,12 +541,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
-			"integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+			"integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "7.13.1",
+				"@typescript-eslint/types": "7.18.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
@@ -573,9 +576,9 @@
 			"license": "ISC"
 		},
 		"node_modules/acorn": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -738,18 +741,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.toreversed": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
-			"integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"node_modules/array.prototype.tosorted": {
@@ -1272,35 +1263,35 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.34.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.2.tgz",
-			"integrity": "sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==",
+			"version": "7.35.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
+			"integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
 			"license": "MIT",
 			"dependencies": {
 				"array-includes": "^3.1.8",
 				"array.prototype.findlast": "^1.2.5",
 				"array.prototype.flatmap": "^1.3.2",
-				"array.prototype.toreversed": "^1.1.2",
-				"array.prototype.tosorted": "^1.1.3",
+				"array.prototype.tosorted": "^1.1.4",
 				"doctrine": "^2.1.0",
 				"es-iterator-helpers": "^1.0.19",
 				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.1.2",
 				"object.entries": "^1.1.8",
 				"object.fromentries": "^2.0.8",
-				"object.hasown": "^1.1.4",
 				"object.values": "^1.2.0",
 				"prop-types": "^15.8.1",
 				"resolve": "^2.0.0-next.5",
 				"semver": "^6.3.1",
-				"string.prototype.matchall": "^4.0.11"
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=4"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
@@ -1470,9 +1461,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -1769,9 +1760,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.6.0.tgz",
-			"integrity": "sha512-UzcJi88Hw//CurUIRa9Jxb0vgOCcuD/MNjwmXp633cyaRKkCWACkoqHCtfZv43b1kqXGg/fpOa8bwgacCeXsVg==",
+			"version": "15.9.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2052,12 +2043,15 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.0"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2492,9 +2486,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -2528,10 +2522,13 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
 			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2584,23 +2581,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.hasown": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-			"integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-			"license": "MIT",
-			"dependencies": {
 				"define-properties": "^1.2.1",
 				"es-abstract": "^1.23.2",
 				"es-object-atoms": "^1.0.0"
@@ -2965,9 +2945,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -3080,6 +3060,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"license": "MIT",
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
 			}
 		},
 		"node_modules/string.prototype.trim": {
@@ -3307,9 +3297,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3320,14 +3310,14 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.1.tgz",
-			"integrity": "sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.18.0.tgz",
+			"integrity": "sha512-PonBkP603E3tt05lDkbOMyaxJjvKqQrXsnow72sVeOFINDE/qNmnnd+f9b4N+U7W6MXnnYyrhtmF2t08QWwUbA==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "7.13.1",
-				"@typescript-eslint/parser": "7.13.1",
-				"@typescript-eslint/utils": "7.13.1"
+				"@typescript-eslint/eslint-plugin": "7.18.0",
+				"@typescript-eslint/parser": "7.18.0",
+				"@typescript-eslint/utils": "7.18.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 			"devDependencies": {
 				"@types/eslint__js": "^8.42.3",
 				"eslint": "^8.57.0",
-				"typescript": "^5.4.5"
+				"typescript": "^5.5.3"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=15.3.0"
@@ -3307,9 +3307,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
 	},
 	"dependencies": {
 		"@eslint/js": "^8.57.0",
-		"@stylistic/eslint-plugin": "^2.2.1",
-		"eslint-plugin-react": "^7.34.1",
+		"@stylistic/eslint-plugin": "^2.3.0",
+		"eslint-plugin-react": "^7.35.0",
 		"eslint-plugin-react-hooks": "^4.6.2",
-		"globals": "^15.6.0",
-		"typescript-eslint": "^7.13.1"
+		"globals": "^15.9.0",
+		"typescript-eslint": "^7.18.0"
 	},
 	"devDependencies": {
 		"@types/eslint": "^8.56.11",
 		"@types/eslint__js": "^8.42.3",
 		"eslint": "^8.57.0",
-		"typescript": "^5.5.3"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"eslint": ">=8.21.0 <9.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"devDependencies": {
 		"@types/eslint__js": "^8.42.3",
 		"eslint": "^8.57.0",
-		"typescript": "^5.4.5"
+		"typescript": "^5.5.3"
 	},
 	"peerDependencies": {
 		"eslint": ">=8.21.0 <9.0.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"typescript-eslint": "^7.13.1"
 	},
 	"devDependencies": {
+		"@types/eslint": "^8.56.11",
 		"@types/eslint__js": "^8.42.3",
 		"eslint": "^8.57.0",
 		"typescript": "^5.5.3"

--- a/src/@types/eslint-plugin-react-hooks.d.ts
+++ b/src/@types/eslint-plugin-react-hooks.d.ts
@@ -1,4 +1,5 @@
 // This is only a type-shim and is not meant to be a perfect representation
+// https://github.com/facebook/react/issues/30119
 
 declare module 'eslint-plugin-react-hooks' {
 	import type { ESLint } from 'eslint';

--- a/src/@types/eslint-plugin-react.d.ts
+++ b/src/@types/eslint-plugin-react.d.ts
@@ -1,4 +1,5 @@
 // This is only a type-shim and is not meant to be a perfect representation
+// https://github.com/jsx-eslint/eslint-plugin-react/issues/3776
 
 declare module 'eslint-plugin-react' {
 	import type { ESLint } from 'eslint';

--- a/src/react.ts
+++ b/src/react.ts
@@ -3,14 +3,13 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import type { Linter } from 'eslint';
 import globals from 'globals';
 
-import { javascript } from './javascript.js';
-
 /** @returns ESLint configuration for React. */
 export function react(): Linter.FlatConfig[] {
 	return [
 		// Make sure to give browser globals to all other project files, not just JSX files
 		{
-			files: javascript()[0]?.files,
+			// FIXME Reused code from src/javascript.ts - abstract out
+			files: ['**/*.{m,c,}{js,ts}{x,}'],
 			languageOptions: {
 				globals: globals.browser,
 			},

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -32,7 +32,7 @@ export function typescript(): Linter.FlatConfig[] {
 				...tsESLint.configs.stylisticTypeChecked[2]?.rules,
 
 				// Overrides
-				'no-shadow': 0, // handled by TypeScript
+				'no-shadow': 0, // TODO Replace with @typescript-eslint/no-shadow (breaking change)
 			},
 		},
 	];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,14 @@
 		"outDir": "dist",
 		"declaration": true,
 		"strict": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noPropertyAccessFromIndexSignature": true,
 		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitReturns": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
 		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"isolatedDeclarations": true,
 
 		// For the globals package
 		"resolveJsonModule": true,


### PR DESCRIPTION
### Added

- `exactOptionalPropertyTypes` to tsconfig
- `isolatedModules` and `isolatedDeclarations` to tsconfig
- Issue links to type shims
- Notes for future lint rule breaking changes

### Changed

- All dependencies to latest versions
- `vscode-eslint` flat config support to be stable
- React rules to not import JavaScript rules

### Removed

- `noFallthroughCasesInSwitch` from tsconfig (handled better by eslint)