### PR TITLE
Make type-shims more specific

### DIFF
--- a/src/@types/eslint-plugin-react-hooks.d.ts
+++ b/src/@types/eslint-plugin-react-hooks.d.ts
@@ -1,10 +1,13 @@
-// This is only a type-shim and is not meant to be a perfect representation of eslint-plugin-react-hooks.
+// This is only a type-shim and is not meant to be a perfect representation
 
 declare module 'eslint-plugin-react-hooks' {
 	import type { ESLint } from 'eslint';
-	const plugin: Omit<ESLint.Plugin, 'configs'> & {
-		// eslint-plugin-react-hooks does not use FlatConfig yet
-		configs: Record<string, ESLint.ConfigData>;
+	const plugin: {
+		rules: ESLint.Plugin['rules'];
+		// Does not use FlatConfig yet
+		configs: {
+			recommended: ESLint.ConfigData;
+		};
 	};
 	export default plugin;
 }

--- a/src/@types/eslint-plugin-react.d.ts
+++ b/src/@types/eslint-plugin-react.d.ts
@@ -1,10 +1,16 @@
-// This is only a type-shim and is not meant to be a perfect representation of eslint-plugin-react.
+// This is only a type-shim and is not meant to be a perfect representation
 
 declare module 'eslint-plugin-react' {
 	import type { ESLint } from 'eslint';
-	const plugin: Omit<ESLint.Plugin, 'configs'> & {
-		// eslint-plugin-react does not use FlatConfig yet
-		configs: Record<string, ESLint.ConfigData>;
+	const plugin: {
+		deprecatedRules: ESLint.Plugin['rules'];
+		rules: ESLint.Plugin['rules'];
+		// Does not use FlatConfig yet
+		configs: {
+			'recommended': ESLint.ConfigData;
+			'all': ESLint.ConfigData;
+			'jsx-runtime': ESLint.ConfigData;
+		};
 	};
 	export default plugin;
 }

--- a/src/react.ts
+++ b/src/react.ts
@@ -33,9 +33,9 @@ export function react(): Linter.FlatConfig[] {
 			},
 			rules: {
 				// Recommended
-				...reactHooksPlugin.configs['recommended']?.rules,
 				...reactPlugin.configs.recommended.rules,
 				...reactPlugin.configs['jsx-runtime'].rules,
+				...reactHooksPlugin.configs.recommended.rules,
 			},
 		},
 	];

--- a/src/react.ts
+++ b/src/react.ts
@@ -22,7 +22,7 @@ export function react(): Linter.FlatConfig[] {
 				'react-hooks': reactHooksPlugin,
 			},
 			languageOptions: {
-				parserOptions: reactPlugin.configs['recommended']?.parserOptions,
+				parserOptions: reactPlugin.configs.recommended.parserOptions,
 			},
 			settings: {
 				react: {
@@ -33,9 +33,9 @@ export function react(): Linter.FlatConfig[] {
 			},
 			rules: {
 				// Recommended
-				...reactPlugin.configs['recommended']?.rules,
-				...reactPlugin.configs['jsx-runtime']?.rules,
 				...reactHooksPlugin.configs['recommended']?.rules,
+				...reactPlugin.configs.recommended.rules,
+				...reactPlugin.configs['jsx-runtime'].rules,
 			},
 		},
 	];


### PR DESCRIPTION
### Changed

- Type shims for `eslint-plugin-react` and `eslint-plugin-react-hooks` to be more specific