### PR TITLE
Remove redundant vscode eslint extension settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"eslint.useFlatConfig": true,
-}


### PR DESCRIPTION
With eslint v9, `eslint.useFlatConfig` now defaults to `true`