### PR TITLE
Replace `eslint-plugin-react` with `@eslint-react/eslint-plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** update `eslint-plugin-react-hooks` from v4 to v7 ([#33](https://github.com/JstnMcBrd/eslint-config/pull/33), [#138](https://github.com/JstnMcBrd/eslint-config/pull/138))
 - **Breaking:** update `@eslint/js` from v8 to v9 ([#143](https://github.com/JstnMcBrd/eslint-config/pull/143))
 - **Breaking:** upgrade to `eslint` v9 ([#143](https://github.com/JstnMcBrd/eslint-config/pull/143))
-- **Breaking:** enable `eslint-plugin-react-hooks` compiler rules ([#145](https://github.com/JstnMcBrd/eslint-config/pull/145))
 - Use `Config` type instead of `Linter.Config` ([#149](https://github.com/JstnMcBrd/eslint-config/pull/149))
 - **Breaking:** use `projectService` for `typescript-eslint` typed linting ([#150](https://github.com/JstnMcBrd/eslint-config/pull/150))
 
@@ -31,11 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** add `@typescript-eslint/prefer-enum-initializers` rule ([#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
 - Add JSDoc to type definitions ([#19](https://github.com/JstnMcBrd/eslint-config/pull/19))
 - Add a `CHANGELOG.md` file ([#142](https://github.com/JstnMcBrd/eslint-config/pull/142))
+- **Breaking:** enable `eslint-plugin-react-hooks` compiler rules ([#145](https://github.com/JstnMcBrd/eslint-config/pull/145))
+- **Breaking:** add `@eslint-react/eslint-plugin` strict config ([#154](https://github.com/JstnMcBrd/eslint-config/pull/154))
 
 ### Removed
 
 - Remove Node runtime restrictions and just rely on dependencies ([#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
 - Remove redundant `"main"` and `"types"` fields from `package.json` ([#41](https://github.com/JstnMcBrd/eslint-config/pull/41))
+- **Breaking:** remove `eslint-plugin-react` configs ([#154](https://github.com/JstnMcBrd/eslint-config/pull/154))
 
 ## [1.0.0] - 2024-02-09
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A simple [ESLint](https://eslint.org/) configuration for JavaScript, [TypeScript](https://www.typescriptlang.org/), and [React](https://react.dev/) projects.
 
-Uses [@eslint/js](https://www.npmjs.com/package/@eslint/js), [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin), [typescript-eslint](https://www.npmjs.com/package/typescript-eslint), [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react), and [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) configurations.
+Uses [@eslint/js](https://www.npmjs.com/package/@eslint/js), [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin), [typescript-eslint](https://www.npmjs.com/package/typescript-eslint), [@eslint-react/eslint-plugin](https://www.npmjs.com/package/@eslint-react/eslint-plugin), and [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) configurations.
 
 Written in TypeScript and transpiles to JavaScript (ESM).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "2.0.0-alpha",
 			"license": "ISC",
 			"dependencies": {
+				"@eslint-react/eslint-plugin": "^2.3.3-beta.1",
 				"@eslint/js": "^9.39.0",
 				"@stylistic/eslint-plugin": "^5.5.0",
-				"eslint-plugin-react": "^7.37.5",
 				"eslint-plugin-react-hooks": "^7.0.1",
 				"globals": "^16.5.0",
 				"typescript-eslint": "^8.46.2"
@@ -78,6 +78,15 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@babel/generator": {
 			"version": "7.28.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
@@ -108,6 +117,15 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-globals": {
@@ -288,6 +306,110 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@eslint-react/ast": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.3.3-beta.1.tgz",
+			"integrity": "sha512-M0TdtjAG477SUiBkpFwoW/X5zON1PT3QvSzPY11dib0o7UpHUv4c1IkLJn25k8qIgqb/8TIGhDSJGi+lZVU3ig==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/typescript-estree": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"string-ts": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@eslint-react/core": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.3.3-beta.1.tgz",
+			"integrity": "sha512-QWdmYd/79+DG1H5+CaGnvHenAN+3K9szdXeCLiCGCNqY5H9hFKzXb6BpgigVqefrQ5IfGh7JdvuC6CEbGIzjfg==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"birecord": "^0.1.1",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@eslint-react/eff": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.3.3-beta.1.tgz",
+			"integrity": "sha512-p8rHedyZNorIwNfeLShns/ScR+5iahaJn8GV7ADojTJGjX04E48YSz1M3rC1eqa/IfYRVuyPeRmESnrdth4Ehw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@eslint-react/eslint-plugin": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.3.3-beta.1.tgz",
+			"integrity": "sha512-E1fZlbP+KEq78oGM0joC+w6+0gjHHRyKrQmyPZlJ1lORXHRoroakCmv7PLnsUiDtr8H60BiF/ub7f/PyJBxdLw==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/type-utils": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"eslint-plugin-react-dom": "2.3.3-beta.1",
+				"eslint-plugin-react-hooks-extra": "2.3.3-beta.1",
+				"eslint-plugin-react-naming-convention": "2.3.3-beta.1",
+				"eslint-plugin-react-web-api": "2.3.3-beta.1",
+				"eslint-plugin-react-x": "2.3.3-beta.1",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
+			}
+		},
+		"node_modules/@eslint-react/shared": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.3.3-beta.1.tgz",
+			"integrity": "sha512-bGPsmpT9NSSqnqsoXsjgPeVEl2U78TWS5ViqBDdZtTAbges0ZFWNLs2ewaJfOI7J7Ef1gzTc9rGYltqBatjWWg==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@typescript-eslint/utils": "^8.46.3",
+				"ts-pattern": "^5.9.0",
+				"zod": "^4.1.12"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@eslint-react/var": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.3.3-beta.1.tgz",
+			"integrity": "sha512-zC7Zmms1szEir4YoaGlbTJYH+voFb8k/f59DkqWl42K/MunpM5/i8REblFQJD8CJc1XWZxEWAI1m5foy+e7MzA==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
 		"node_modules/@eslint/config-array": {
 			"version": "0.21.1",
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
@@ -300,6 +422,28 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
@@ -349,6 +493,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -361,10 +515,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.0.tgz",
-			"integrity": "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw==",
+			"version": "9.39.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+			"integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -556,16 +722,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
-			"integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.3.tgz",
+			"integrity": "sha512-sbaQ27XBUopBkRiuY/P9sWGOWUW4rl8fDoHIUmLpZd8uldsTyB4/Zg6bWTegPoTLnKj9Hqgn3QD6cjPNB32Odw==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.46.2",
-				"@typescript-eslint/type-utils": "8.46.2",
-				"@typescript-eslint/utils": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2",
+				"@typescript-eslint/scope-manager": "8.46.3",
+				"@typescript-eslint/type-utils": "8.46.3",
+				"@typescript-eslint/utils": "8.46.3",
+				"@typescript-eslint/visitor-keys": "8.46.3",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -579,7 +745,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.46.2",
+				"@typescript-eslint/parser": "^8.46.3",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
@@ -594,15 +760,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
+			"integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.2",
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2",
+				"@typescript-eslint/scope-manager": "8.46.3",
+				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/typescript-estree": "8.46.3",
+				"@typescript-eslint/visitor-keys": "8.46.3",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -618,13 +784,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
-			"integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.3.tgz",
+			"integrity": "sha512-Fz8yFXsp2wDFeUElO88S9n4w1I4CWDTXDqDr9gYvZgUpwXQqmZBr9+NTTql5R3J7+hrJZPdpiWaB9VNhAKYLuQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.46.2",
-				"@typescript-eslint/types": "^8.46.2",
+				"@typescript-eslint/tsconfig-utils": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -639,13 +805,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
-			"integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.3.tgz",
+			"integrity": "sha512-FCi7Y1zgrmxp3DfWfr+3m9ansUUFoy8dkEdeQSgA9gbm8DaHYvZCdkFRQrtKiedFf3Ha6VmoqoAaP68+i+22kg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2"
+				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/visitor-keys": "8.46.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -656,9 +822,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
-			"integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.3.tgz",
+			"integrity": "sha512-GLupljMniHNIROP0zE7nCcybptolcH8QZfXOpCfhQDAdwJ/ZTlcaBOYebSOZotpti/3HrHSw7D3PZm75gYFsOA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -672,14 +838,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
-			"integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.3.tgz",
+			"integrity": "sha512-ZPCADbr+qfz3aiTTYNNkCbUt+cjNwI/5McyANNrFBpVxPt7GqpEYz5ZfdwuFyGUnJ9FdDXbGODUu6iRCI6XRXw==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2",
-				"@typescript-eslint/utils": "8.46.2",
+				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/typescript-estree": "8.46.3",
+				"@typescript-eslint/utils": "8.46.3",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -696,9 +862,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
-			"integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.3.tgz",
+			"integrity": "sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -709,15 +875,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
-			"integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.3.tgz",
+			"integrity": "sha512-f/NvtRjOm80BtNM5OQtlaBdM5BRFUv7gf381j9wygDNL+qOYSNOgtQ/DCndiYi80iIOv76QqaTmp4fa9hwI0OA==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.46.2",
-				"@typescript-eslint/tsconfig-utils": "8.46.2",
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2",
+				"@typescript-eslint/project-service": "8.46.3",
+				"@typescript-eslint/tsconfig-utils": "8.46.3",
+				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/visitor-keys": "8.46.3",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -736,52 +902,16 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
-			"integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.3.tgz",
+			"integrity": "sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.46.2",
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2"
+				"@typescript-eslint/scope-manager": "8.46.3",
+				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/typescript-estree": "8.46.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -796,12 +926,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
-			"integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.3.tgz",
+			"integrity": "sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.2",
+				"@typescript-eslint/types": "8.46.3",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -870,161 +1000,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"license": "Python-2.0"
 		},
-		"node_modules/array-buffer-byte-length": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-			"integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"is-array-buffer": "^3.0.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array-includes": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-			"integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.24.0",
-				"es-object-atoms": "^1.1.1",
-				"get-intrinsic": "^1.3.0",
-				"is-string": "^1.1.1",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.findlast": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.flat": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-			"integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.flatmap": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-			"integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.tosorted": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.3",
-				"es-errors": "^1.3.0",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-			"integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-			"license": "MIT",
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.1",
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"is-array-buffer": "^3.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/async-function": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-			"integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"possible-typed-array-names": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1032,22 +1007,27 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.8.23",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
-			"integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
+			"version": "2.8.25",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
+			"integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.js"
 			}
 		},
+		"node_modules/birecord": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.1.tgz",
+			"integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
+			"license": "(MIT OR Apache-2.0)"
+		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -1095,53 +1075,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
-				"set-function-length": "^1.2.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/call-bound": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"get-intrinsic": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1152,9 +1085,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001753",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
-			"integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
+			"version": "1.0.30001754",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
+			"integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1205,6 +1138,12 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
+		"node_modules/compare-versions": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+			"integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+			"license": "MIT"
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1231,57 +1170,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/data-view-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-			"integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/data-view-byte-length": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-			"integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/inspect-js"
-			}
-		},
-		"node_modules/data-view-byte-offset": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-			"integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1305,240 +1193,11 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"license": "MIT"
 		},
-		"node_modules/define-data-property": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"license": "MIT",
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.244",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
-			"integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
+			"version": "1.5.246",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.246.tgz",
+			"integrity": "sha512-CKp2enkTcw94o8p7P+nb3in3yILO7jAIoERSmkIhGazMuK2eLnPSVUH/dxUveGN8ulJJDjYUv0vV7y2e2AZ0nA==",
 			"license": "ISC"
-		},
-		"node_modules/es-abstract": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
-			"license": "MIT",
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.2",
-				"arraybuffer.prototype.slice": "^1.0.4",
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"data-view-buffer": "^1.0.2",
-				"data-view-byte-length": "^1.0.2",
-				"data-view-byte-offset": "^1.0.1",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"es-set-tostringtag": "^2.1.0",
-				"es-to-primitive": "^1.3.0",
-				"function.prototype.name": "^1.1.8",
-				"get-intrinsic": "^1.3.0",
-				"get-proto": "^1.0.1",
-				"get-symbol-description": "^1.1.0",
-				"globalthis": "^1.0.4",
-				"gopd": "^1.2.0",
-				"has-property-descriptors": "^1.0.2",
-				"has-proto": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"internal-slot": "^1.1.0",
-				"is-array-buffer": "^3.0.5",
-				"is-callable": "^1.2.7",
-				"is-data-view": "^1.0.2",
-				"is-negative-zero": "^2.0.3",
-				"is-regex": "^1.2.1",
-				"is-set": "^2.0.3",
-				"is-shared-array-buffer": "^1.0.4",
-				"is-string": "^1.1.1",
-				"is-typed-array": "^1.1.15",
-				"is-weakref": "^1.1.1",
-				"math-intrinsics": "^1.1.0",
-				"object-inspect": "^1.13.4",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.7",
-				"own-keys": "^1.0.1",
-				"regexp.prototype.flags": "^1.5.4",
-				"safe-array-concat": "^1.1.3",
-				"safe-push-apply": "^1.0.0",
-				"safe-regex-test": "^1.1.0",
-				"set-proto": "^1.0.0",
-				"stop-iteration-iterator": "^1.1.0",
-				"string.prototype.trim": "^1.2.10",
-				"string.prototype.trimend": "^1.0.9",
-				"string.prototype.trimstart": "^1.0.8",
-				"typed-array-buffer": "^1.0.3",
-				"typed-array-byte-length": "^1.0.3",
-				"typed-array-byte-offset": "^1.0.4",
-				"typed-array-length": "^1.0.7",
-				"unbox-primitive": "^1.1.0",
-				"which-typed-array": "^1.1.19"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-iterator-helpers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
-				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.3",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.6",
-				"globalthis": "^1.0.4",
-				"gopd": "^1.2.0",
-				"has-property-descriptors": "^1.0.2",
-				"has-proto": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"internal-slot": "^1.1.0",
-				"iterator.prototype": "^1.1.4",
-				"safe-array-concat": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-shim-unscopables": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-			"integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-to-primitive": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-			"integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-			"license": "MIT",
-			"dependencies": {
-				"is-callable": "^1.2.7",
-				"is-date-object": "^1.0.5",
-				"is-symbol": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -1562,9 +1221,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.0.tgz",
-			"integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
+			"version": "9.39.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
@@ -1573,7 +1232,7 @@
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.0",
+				"@eslint/js": "9.39.1",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -1620,36 +1279,30 @@
 				}
 			}
 		},
-		"node_modules/eslint-plugin-react": {
-			"version": "7.37.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-			"integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+		"node_modules/eslint-plugin-react-dom": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.3.3-beta.1.tgz",
+			"integrity": "sha512-kx0MmOBZzwN7S3F2CZ4TfZ7SZHPi6YZaTOV0g0eDgAC/sY71eHk4LF/N9bk6xwT1Sr/DPdCjySsWLG4Q8KznCg==",
 			"license": "MIT",
 			"dependencies": {
-				"array-includes": "^3.1.8",
-				"array.prototype.findlast": "^1.2.5",
-				"array.prototype.flatmap": "^1.3.3",
-				"array.prototype.tosorted": "^1.1.4",
-				"doctrine": "^2.1.0",
-				"es-iterator-helpers": "^1.2.1",
-				"estraverse": "^5.3.0",
-				"hasown": "^2.0.2",
-				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
-				"minimatch": "^3.1.2",
-				"object.entries": "^1.1.9",
-				"object.fromentries": "^2.0.8",
-				"object.values": "^1.2.1",
-				"prop-types": "^15.8.1",
-				"resolve": "^2.0.0-next.5",
-				"semver": "^6.3.1",
-				"string.prototype.matchall": "^4.0.12",
-				"string.prototype.repeat": "^1.0.0"
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/core": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"compare-versions": "^6.1.1",
+				"string-ts": "^2.2.1",
+				"ts-pattern": "^5.9.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
@@ -1669,6 +1322,112 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-react-hooks-extra": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.3.3-beta.1.tgz",
+			"integrity": "sha512-soriVgqSlxopS4gws8yg61FCTXv2yJt4FDIuk0qg4bWfNq0CyFg2vYFUp4bKnUHkD6eQY2LmPyEoalwFatJZEg==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/core": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/type-utils": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"string-ts": "^2.2.1",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
+			}
+		},
+		"node_modules/eslint-plugin-react-naming-convention": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.3.3-beta.1.tgz",
+			"integrity": "sha512-AHek8fy/kLaBlDkimEGtYsb5kypujUlvQeiQgFj9fAJUubdmHbTR4ZGPcnMxzaL7ylfVQLJcKfGBUDXocJrUHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/core": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/type-utils": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"string-ts": "^2.2.1",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
+			}
+		},
+		"node_modules/eslint-plugin-react-web-api": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.3.3-beta.1.tgz",
+			"integrity": "sha512-psYwCcBTBAFYDl/2u+wIBYV7oN7TphFCfy4MCkpdfPtopmH/NjbPWhrI4hox8tjHDPcXT8DXvGdsec+Jhy6tjA==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/core": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"string-ts": "^2.2.1",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
+			}
+		},
+		"node_modules/eslint-plugin-react-x": {
+			"version": "2.3.3-beta.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.3.3-beta.1.tgz",
+			"integrity": "sha512-HJp2HuozesknLhMXcG84JqVilOcs5eAOV0epBahW6UAhrvf2E7T34clFDp4cB67ZwlD6U1HZt9J0WeX+2mwakw==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-react/ast": "2.3.3-beta.1",
+				"@eslint-react/core": "2.3.3-beta.1",
+				"@eslint-react/eff": "2.3.3-beta.1",
+				"@eslint-react/shared": "2.3.3-beta.1",
+				"@eslint-react/var": "2.3.3-beta.1",
+				"@typescript-eslint/scope-manager": "^8.46.3",
+				"@typescript-eslint/type-utils": "^8.46.3",
+				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/utils": "^8.46.3",
+				"compare-versions": "^6.1.1",
+				"is-immutable-type": "^5.0.1",
+				"string-ts": "^2.2.1",
+				"ts-api-utils": "^2.1.0",
+				"ts-pattern": "^5.9.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9.38.0",
+				"typescript": "^5.9.3"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -1697,6 +1456,28 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/espree": {
@@ -1872,68 +1653,6 @@
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"license": "ISC"
 		},
-		"node_modules/for-each": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-callable": "^1.2.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/function.prototype.name": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-			"integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"functions-have-names": "^1.2.3",
-				"hasown": "^2.0.2",
-				"is-callable": "^1.2.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/functions-have-names": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/generator-function": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1941,60 +1660,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/get-symbol-description": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-			"integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2021,51 +1686,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globalthis": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.2.1",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"license": "MIT"
-		},
-		"node_modules/has-bigints": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-			"integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -2074,72 +1699,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/has-property-descriptors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"license": "MIT",
-			"dependencies": {
-				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-proto": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-			"integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hermes-estree": {
@@ -2191,147 +1750,6 @@
 				"node": ">=0.8.19"
 			}
 		},
-		"node_modules/internal-slot": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-			"integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"hasown": "^2.0.2",
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/is-array-buffer": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-			"integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-async-function": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-			"integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-			"license": "MIT",
-			"dependencies": {
-				"async-function": "^1.0.0",
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.1",
-				"has-tostringtag": "^1.0.2",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-bigint": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-			"integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"has-bigints": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-boolean-object": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-			"integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-data-view": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-			"integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
-				"is-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-date-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2339,40 +1757,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-finalizationregistry": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-			"integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-generator-function": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.4",
-				"generator-function": "^2.0.0",
-				"get-proto": "^1.0.1",
-				"has-tostringtag": "^1.0.2",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-glob": {
@@ -2387,28 +1771,19 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-map": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
+		"node_modules/is-immutable-type": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.1.tgz",
+			"integrity": "sha512-LkHEOGVZZXxGl8vDs+10k3DvP++SEoYEAJLRk6buTFi6kD7QekThV7xHS0j6gpnUCQ0zpud/gMDGiV4dQneLTg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@typescript-eslint/type-utils": "^8.0.0",
+				"ts-api-utils": "^2.0.0",
+				"ts-declaration-location": "^1.0.4"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-negative-zero": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+			"peerDependencies": {
+				"eslint": "*",
+				"typescript": ">=4.7.4"
 			}
 		},
 		"node_modules/is-number": {
@@ -2420,186 +1795,11 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-number-object": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-			"integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-regex": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"gopd": "^1.2.0",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-set": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-			"integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-string": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-			"integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-symbol": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-			"integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-symbols": "^1.1.0",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"which-typed-array": "^1.1.16"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakmap": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakref": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-			"integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakset": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-			"integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"license": "MIT"
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
-		},
-		"node_modules/iterator.prototype": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-			"integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-object-atoms": "^1.0.0",
-				"get-intrinsic": "^1.2.6",
-				"get-proto": "^1.0.0",
-				"has-symbols": "^1.1.0",
-				"set-function-name": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
 		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
@@ -2671,21 +1871,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsx-ast-utils": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
-			"license": "MIT",
-			"dependencies": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flat": "^1.3.1",
-				"object.assign": "^4.1.4",
-				"object.values": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2729,18 +1914,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"license": "MIT"
 		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2748,15 +1921,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/merge2": {
@@ -2794,15 +1958,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ms": {
@@ -2823,107 +1990,6 @@
 			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"license": "MIT"
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-inspect": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0",
-				"has-symbols": "^1.1.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.entries": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-			"integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.fromentries": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.values": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-			"integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2939,23 +2005,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/own-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.2.6",
-				"object-keys": "^1.1.1",
-				"safe-push-apply": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/p-limit": {
@@ -3018,12 +2067,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"license": "MIT"
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3042,15 +2085,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/possible-typed-array-names": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3058,17 +2092,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/prop-types": {
-			"version": "15.8.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.13.1"
 			}
 		},
 		"node_modules/punycode": {
@@ -3099,71 +2122,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
-		"node_modules/reflect.getprototypeof": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-			"integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.9",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"get-intrinsic": "^1.2.7",
-				"get-proto": "^1.0.1",
-				"which-builtin-type": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-errors": "^1.3.0",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"set-function-name": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
@@ -3207,111 +2165,16 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/safe-array-concat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
-				"has-symbols": "^1.1.0",
-				"isarray": "^2.0.5"
-			},
-			"engines": {
-				"node": ">=0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-push-apply": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-			"integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"isarray": "^2.0.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-regex-test": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"is-regex": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/set-function-length": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-function-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"functions-have-names": "^1.2.3",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-proto": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-			"integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
+				"node": ">=10"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -3335,183 +2198,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
-				"side-channel-map": "^1.0.1",
-				"side-channel-weakmap": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-map": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-weakmap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3",
-				"side-channel-map": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/stop-iteration-iterator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-			"integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"internal-slot": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/string.prototype.matchall": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-			"integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"get-intrinsic": "^1.2.6",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"internal-slot": "^1.1.0",
-				"regexp.prototype.flags": "^1.5.3",
-				"set-function-name": "^2.0.2",
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.repeat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"node_modules/string.prototype.trim": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-			"integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"define-data-property": "^1.1.4",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-object-atoms": "^1.0.0",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimend": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-			"integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+		"node_modules/string-ts": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.2.1.tgz",
+			"integrity": "sha512-Q2u0gko67PLLhbte5HmPfdOjNvUKbKQM+mCNQae6jE91DmoFHY6HH9GcdqCeNx87DZ2KKjiFxmA0R/42OneGWw==",
+			"license": "MIT"
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -3535,18 +2226,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -3573,6 +2252,34 @@
 				"typescript": ">=4.8.4"
 			}
 		},
+		"node_modules/ts-declaration-location": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+			"integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+			"funding": [
+				{
+					"type": "ko-fi",
+					"url": "https://ko-fi.com/rebeccastevens"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"picomatch": "^4.0.2"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.0.0"
+			}
+		},
+		"node_modules/ts-pattern": {
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+			"integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+			"license": "MIT"
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3583,80 +2290,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/typed-array-buffer": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/typed-array-byte-length": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-			"integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"for-each": "^0.3.3",
-				"gopd": "^1.2.0",
-				"has-proto": "^1.2.0",
-				"is-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-byte-offset": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-			"integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
-				"for-each": "^0.3.3",
-				"gopd": "^1.2.0",
-				"has-proto": "^1.2.0",
-				"is-typed-array": "^1.1.15",
-				"reflect.getprototypeof": "^1.0.9"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-length": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-			"integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"is-typed-array": "^1.1.13",
-				"possible-typed-array-names": "^1.0.0",
-				"reflect.getprototypeof": "^1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/typescript": {
@@ -3673,15 +2306,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
-			"integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
+			"version": "8.46.3",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.3.tgz",
+			"integrity": "sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.46.2",
-				"@typescript-eslint/parser": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2",
-				"@typescript-eslint/utils": "8.46.2"
+				"@typescript-eslint/eslint-plugin": "8.46.3",
+				"@typescript-eslint/parser": "8.46.3",
+				"@typescript-eslint/typescript-estree": "8.46.3",
+				"@typescript-eslint/utils": "8.46.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3693,24 +2326,6 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/unbox-primitive": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-			"integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-bigints": "^1.0.2",
-				"has-symbols": "^1.1.0",
-				"which-boxed-primitive": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -3765,91 +2380,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-boxed-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-			"integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-bigint": "^1.1.0",
-				"is-boolean-object": "^1.2.1",
-				"is-number-object": "^1.1.1",
-				"is-string": "^1.1.1",
-				"is-symbol": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-builtin-type": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-			"integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"function.prototype.name": "^1.1.6",
-				"has-tostringtag": "^1.0.2",
-				"is-async-function": "^2.0.0",
-				"is-date-object": "^1.1.0",
-				"is-finalizationregistry": "^1.1.0",
-				"is-generator-function": "^1.0.10",
-				"is-regex": "^1.2.1",
-				"is-weakref": "^1.0.2",
-				"isarray": "^2.0.5",
-				"which-boxed-primitive": "^1.1.0",
-				"which-collection": "^1.0.2",
-				"which-typed-array": "^1.1.16"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-collection": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-map": "^2.0.3",
-				"is-set": "^2.0.3",
-				"is-weakmap": "^2.0.2",
-				"is-weakset": "^2.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-			"license": "MIT",
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"for-each": "^0.3.5",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
 		"lint": "eslint"
 	},
 	"dependencies": {
+		"@eslint-react/eslint-plugin": "^2.3.3-beta.1",
 		"@eslint/js": "^9.39.0",
 		"@stylistic/eslint-plugin": "^5.5.0",
-		"eslint-plugin-react": "^7.37.5",
 		"eslint-plugin-react-hooks": "^7.0.1",
 		"globals": "^16.5.0",
 		"typescript-eslint": "^8.46.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ interface Settings {
 export default function eslintConfig(settings?: Settings): Config[] {
 	return defineConfig([
 		...javascript(),
-		...(settings?.react ? react() : []),
+		...(settings?.react ? react(settings) : []),
 		...(settings?.typescript ? typescript() : []),
 	]);
 }

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,27 +1,19 @@
 import type { Config } from 'eslint/config';
-import reactPlugin from 'eslint-plugin-react';
+import reactPlugin from '@eslint-react/eslint-plugin';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 /** @returns ESLint configuration for React. */
-export function react(): Config[] {
+export function react(settings: { typescript?: boolean }): Config[] {
 	return [
 		{
 			languageOptions: {
 				globals: globals.browser,
 			},
-			settings: {
-				react: {
-					// TODO Warns if not set, but will default to 'detect' in the future
-					// https://github.com/jsx-eslint/eslint-plugin-react/issues/3758
-					version: 'detect',
-				},
-			},
 		},
 
 		// Recommended
-		reactPlugin.configs.flat['recommended'] ?? {},
-		reactPlugin.configs.flat['jsx-runtime'] ?? {},
+		reactPlugin.configs[settings.typescript ? 'strict-type-checked' : 'strict'],
 		reactHooksPlugin.configs.flat['recommended-latest'],
 	];
 }


### PR DESCRIPTION
- More modern
- TypeScript-first
- Faster
- More rules
- Less dependencies / smaller bundle size
- Active development