### PR TITLE
Remove default globals for NodeJS and browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Order "react" and "typescript" options alphabetically ([#4](https://github.com/JstnMcBrd/eslint-config/pull/4))
 - **Breaking:** update `typescript-eslint` to v6 to v8 ([#6](https://github.com/JstnMcBrd/eslint-config/pull/6), [#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
-- Update `globals` to v13 to v16 ([#8](https://github.com/JstnMcBrd/eslint-config/pull/8), [#73](https://github.com/JstnMcBrd/eslint-config/pull/73))
 - **Breaking:** update `@stylistic/eslint-plugin` from v1 to v5 ([#9](https://github.com/JstnMcBrd/eslint-config/pull/9), [#143](https://github.com/JstnMcBrd/eslint-config/pull/143))
 - Improve wording in README ([#11](https://github.com/JstnMcBrd/eslint-config/pull/11))
 - Use `customize()` method for stylistic rule overrides ([#11](https://github.com/JstnMcBrd/eslint-config/pull/11))
@@ -39,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove Node runtime restrictions and just rely on dependencies ([#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
 - Remove redundant `"main"` and `"types"` fields from `package.json` ([#41](https://github.com/JstnMcBrd/eslint-config/pull/41))
 - **Breaking:** remove `eslint-plugin-react` configs ([#154](https://github.com/JstnMcBrd/eslint-config/pull/154))
+- **Breaking:** remove default globals for NodeJS and browser ([#158](https://github.com/JstnMcBrd/eslint-config/pull/158))
 
 ## [1.0.0] - 2024-02-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"@eslint/js": "^9.39.0",
 				"@stylistic/eslint-plugin": "^5.5.0",
 				"eslint-plugin-react-hooks": "^7.0.1",
-				"globals": "^16.5.0",
 				"typescript-eslint": "^8.46.2"
 			},
 			"devDependencies": {
@@ -1672,18 +1671,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/graphemer": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"@eslint/js": "^9.39.0",
 		"@stylistic/eslint-plugin": "^5.5.0",
 		"eslint-plugin-react-hooks": "^7.0.1",
-		"globals": "^16.5.0",
 		"typescript-eslint": "^8.46.2"
 	},
 	"devDependencies": {

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -2,7 +2,6 @@ import js from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
 import type { Config } from 'eslint/config';
 import { defineConfig } from 'eslint/config';
-import globals from 'globals';
 
 /** @returns Basic ESLint configuration for JavaScript. */
 export function javascript(): Config[] {
@@ -10,17 +9,15 @@ export function javascript(): Config[] {
 		{
 			files: ['**/*.{m,c,}{js,ts}{x,}'],
 		},
+
+		// Report unnecessary eslint-disable comments
 		{
-			languageOptions: {
-				// FIXME What if this is not a node project (like bundling for a browser)?
-				globals: globals.nodeBuiltin,
-			},
 			linterOptions: {
 				reportUnusedDisableDirectives: 'error',
 			},
 		},
 
-		// Recommended
+		// Defaults
 		js.configs.recommended,
 		stylistic.configs.customize({
 			indent: 'tab',

--- a/src/react.ts
+++ b/src/react.ts
@@ -2,18 +2,11 @@ import reactPlugin from '@eslint-react/eslint-plugin';
 import type { Config } from 'eslint/config';
 import { defineConfig } from 'eslint/config';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
-import globals from 'globals';
 
 /** @returns ESLint configuration for React. */
 export function react(settings: { typescript?: boolean }): Config[] {
 	return defineConfig(
-		{
-			languageOptions: {
-				globals: globals.browser,
-			},
-		},
-
-		// Recommended
+		// Defaults
 		reactPlugin.configs[settings.typescript ? 'strict-type-checked' : 'strict'],
 		reactHooksPlugin.configs.flat['recommended-latest'],
 	);

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -17,7 +17,7 @@ export function typescript(): Config[] {
 			},
 		},
 
-		// Recommended
+		// Defaults
 		typescriptESLint.configs.strictTypeChecked,
 		typescriptESLint.configs.stylisticTypeChecked,
 


### PR DESCRIPTION
Including default globals requires making assumptions about the environment. Right now, we automatically include NodeJS globals, but this config could be used in a Deno or Bun environment, or for a browser-only project. It makes more sense to allow users to extend the config and add their own globals if necessary.

Besides, globals are unnecessary for TypeScript projects, and all of my projects are TypeScript.

This may be a small inconvenience for JavaScript-only projects. Let that be motivation to migrate to TypeScript :)