### PR TITLE
Remove open PR limit for GitHub Actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1000


### PR DESCRIPTION
It seems I forgot to add include `open-pull-requests-limit` when I added the GitHub Actions dependabot config.