### PR TITLE
Add missing exports field in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing exports field in `package.json` ([#171](https://github.com/JstnMcBrd/eslint-config/pull/171))
+
 ## [2.0.0] - 2025-11-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
 	"license": "ISC",
 	"author": "Justin McBride",
 	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
I removed the `"main"` field in #41, but forgot that I hadn't added an `"exports"` field yet, unlike my other packages.

So right now, there is no exposed import path for the package, which makes it impossible to import, which makes v2.0.0 completely unusable. How embarrassing.