### PR TITLE
Only support `eslint` v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Support `eslint` v10 ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234))
+- **Breaking:** upgrade to `eslint` v10 ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#235](https://github.com/JstnMcBrd/eslint-config/pull/235))
 - **Breaking:** update Node requirement to `^20.19.0 || ^22.13.0 || >=24` ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234))
 - **Breaking:** update `@eslint/js` from v9 to v10 ([#201](https://github.com/JstnMcBrd/eslint-config/pull/201))
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default defineConfig(
 
 #### Modern
 
-- Only compatible with ESLint v9
+- Only compatible with ESLint v10
 - Uses the new ESLint [flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new)
 - No support for the legacy config, so consider upgrading!
 
@@ -128,7 +128,7 @@ export default defineConfig(
 
 - Does not use [Prettier](https://prettier.io/)
 	- It's good to be standardized and opinionated, but I find Prettier to be inflexible and dogmatic. I created this package to enforce my own dogmatic opinions instead.
-	- There's an interesting debate about the purposes of formatters versus linters. Strict formatters often erase context encoded in code style, so flexibility can be useful for retaining the intent of the programmer.
+	- Strict formatters often erase context encoded in code style, so flexibility can be useful for retaining the intent of the programmer.
 	- For another perspective, see Anthony Fu's [blog post](https://antfu.me/posts/why-not-prettier) on the subject.
 
 ## Semantic versioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"peerDependencies": {
-				"eslint": "^9.22.0 || ^10.0.0"
+				"eslint": "^10.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {
-		"eslint": "^9.22.0 || ^10.0.0"
+		"eslint": "^10.0.0"
 	},
 	"engines": {
 		"node": "^20.19.0 || ^22.13.0 || >=24"


### PR DESCRIPTION
Apparently `@eslint/js@10` only supports `eslint@10`, so I can't support both v9 and v10 at the same time.