### PR TITLE
Load `eslint.config.ts` with native Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** upgrade to `eslint` v10 ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#235](https://github.com/JstnMcBrd/eslint-config/pull/235))
 - **Breaking:** update Node requirement to `^20.19.0 || ^22.13.0 || >=24` ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234))
 - **Breaking:** update `@eslint/js` from v9 to v10 ([#201](https://github.com/JstnMcBrd/eslint-config/pull/201))
+- Explain how to use `eslint.config.ts` in README ([#236](https://github.com/JstnMcBrd/eslint-config/pull/236))
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ import eslintConfig from '@jstnmcbrd/eslint-config';
 export default eslintConfig();
 ```
 
+Alternatively, you can use a TypeScript config file instead (`eslint.config.ts`). This requires Node `>=22.18.0`, and you must add `--flag unstable_native_nodejs_ts_config` to the `"lint"` script in `package.json`.
+
 #### React
 
 ```js

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,9 +1,7 @@
-/**
- * TODO Once strip-types is stable in Node.js, remove jiti dependency
- * @see https://eslint.org/docs/latest/use/configure/configuration-files#native-typescript-support
- */
+// FIXME Need the `unstable_native_nodejs_ts_config` flag to use `eslint.config.ts`
+// https://github.com/eslint/eslint/issues/19985
 
-// Requires you to run `npm run build` before linting
+// Must run `npm run build` before linting
 import eslintConfig from './dist/index.js';
 
 export default eslintConfig({ typescript: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 			},
 			"devDependencies": {
 				"eslint": "^10.2.0",
-				"jiti": "^2.6.1",
 				"typescript": "^5.9.3"
 			},
 			"engines": {
@@ -1593,16 +1592,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
-		},
-		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-			"devOptional": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
-		"lint": "eslint"
+		"lint": "eslint --flag unstable_native_nodejs_ts_config"
 	},
 	"dependencies": {
 		"@eslint-react/eslint-plugin": "^2.13.0",
@@ -38,7 +38,6 @@
 	},
 	"devDependencies": {
 		"eslint": "^10.2.0",
-		"jiti": "^2.6.1",
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
Pros:
- removes a dependency

Cons:
- requires an additional flag

Currently ESLint requires an experiment flag to use native Node type-stripping to load the config file, despite Node type-stripping not being experimental anymore. Hopefully this is resolved soon. 
- https://github.com/eslint/eslint/issues/19985