### PR TITLE
Add `devEngines` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import eslintConfig from '@jstnmcbrd/eslint-config';
 export default eslintConfig();
 ```
 
-Alternatively, you can use a TypeScript config file instead (`eslint.config.ts`). This requires Node `>=22.18.0`, and you must add `--flag unstable_native_nodejs_ts_config` to the `"lint"` script in `package.json`.
+Alternatively, you can use a TypeScript config file instead (`eslint.config.ts`). This requires Node.js `^22.18.0 || >=24`, and you must add `--flag unstable_native_nodejs_ts_config` to the `"lint"` script in `package.json`.
 
 #### React
 

--- a/package.json
+++ b/package.json
@@ -45,5 +45,11 @@
 	},
 	"engines": {
 		"node": "^22.13.0 || >=24"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.18.0 || >=24"
+		}
 	}
 }


### PR DESCRIPTION
Necessary to use `eslint.config.ts` file without `jiti`.

Also, corrected the README on the required Node.js version - not all versions of Node.js 23 supported native TypeScript.