### PR TITLE
Clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - **Breaking:** upgrade to `eslint` v10 ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#235](https://github.com/JstnMcBrd/eslint-config/pull/235))
-- **Breaking:** update Node requirement to `^22.13.0 || >=24` ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
+- **Breaking:** update Node.js requirement to `^22.13.0 || >=24` ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
 - **Breaking:** update `@eslint/js` from v9 to v10 ([#201](https://github.com/JstnMcBrd/eslint-config/pull/201))
 - **Breaking:** update `@eslint-react/eslint-plugin` from v2 to v4 ([#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
 
@@ -69,8 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Breaking:** remove `eslint-plugin-react` configs ([#154](https://github.com/JstnMcBrd/eslint-config/pull/154))
-- **Breaking:** remove default globals for NodeJS and browser ([#158](https://github.com/JstnMcBrd/eslint-config/pull/158))
-- Remove Node runtime restrictions and just rely on dependencies ([#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
+- **Breaking:** remove default globals for Node.js and browser ([#158](https://github.com/JstnMcBrd/eslint-config/pull/158))
+- Remove Node.js runtime restrictions and just rely on dependencies ([#18](https://github.com/JstnMcBrd/eslint-config/pull/18))
 - Remove redundant `"main"` and `"types"` fields from `package.json` ([#41](https://github.com/JstnMcBrd/eslint-config/pull/41))
 
 ## [1.0.0] - 2024-02-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** update Node.js requirement to `^22.13.0 || >=24` ([#234](https://github.com/JstnMcBrd/eslint-config/pull/234), [#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
 - **Breaking:** update `@eslint/js` from v9 to v10 ([#201](https://github.com/JstnMcBrd/eslint-config/pull/201))
 - **Breaking:** update `@eslint-react/eslint-plugin` from v2 to v4 ([#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
+- Clean up README ([#241](https://github.com/JstnMcBrd/eslint-config/pull/241))
 
 ## Added
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export default eslintConfig({ react: true, typescript: true });
 
 If you need to extend the config, you can use the `defineConfig` helper from `eslint`.
 
-For example, you could add NodeJS globals (for a non-TypeScript project).
+For example, you could add Node.js globals (for a non-TypeScript project).
 
 ```js
 import eslintConfig from '@jstnmcbrd/eslint-config';
@@ -117,7 +117,7 @@ export default defineConfig(
 
 - Transpiled by TypeScript to ESM
 - No support for CommonJS, so consider upgrading!
-- This means you cannot import the package from a node project that is not using `"type": "module"`
+- This means you cannot import the package from a Node.js project that is not using `"type": "module"`
 
 #### Simplicity
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # @jstnmcbrd/eslint-config
 
-[![NPM Version](https://img.shields.io/npm/v/@jstnmcbrd/eslint-config)](https://www.npmjs.com/package/@jstnmcbrd/eslint-config)
-[![ESLint version](https://img.shields.io/npm/dependency-version/@jstnmcbrd/eslint-config/peer/eslint)](https://www.npmjs.com/package/eslint)
-[![NPM License](https://img.shields.io/npm/l/@jstnmcbrd/eslint-config)](./LICENSE)
-![NPM Downloads](https://img.shields.io/npm/dt/@jstnmcbrd/eslint-config)
+[![npm version](https://img.shields.io/npm/v/@jstnmcbrd/eslint-config)](https://www.npmjs.com/package/@jstnmcbrd/eslint-config)
+![node version](https://img.shields.io/node/v/delphi-ai)
+[![eslint version](https://img.shields.io/npm/dependency-version/@jstnmcbrd/eslint-config/peer/eslint)](https://www.npmjs.com/package/eslint)
+[![npm license](https://img.shields.io/npm/l/@jstnmcbrd/eslint-config)](./LICENSE)
+![npm downloads](https://img.shields.io/npm/dt/@jstnmcbrd/eslint-config)
 
 ## About
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@eslint-react/eslint-plugin": "^4.2.3",
 		"@eslint/js": "^10.0.1",
 		"@stylistic/eslint-plugin": "^5.10.0",
-		"eslint-plugin-react-hooks": "^7.1.0-canary-e8c63626-20260213",
+		"eslint-plugin-react-hooks": "7.1.0-canary-e8c63626-20260213",
 		"typescript-eslint": "^8.58.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
- Use correct name of Node.js
- Reorganize badges

Other
- Pin canary version of `eslint-plugin-react-hooks`
  - Semver doesn't understand these versions and tries to update backwards, so pinning is safer