### PR TITLE
Divide global include globs by config type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** update `@eslint/js` from v9 to v10 ([#201](https://github.com/JstnMcBrd/eslint-config/pull/201))
 - **Breaking:** update `@eslint-react/eslint-plugin` from v2 to v4 ([#230](https://github.com/JstnMcBrd/eslint-config/pull/230))
 - Clean up README ([#241](https://github.com/JstnMcBrd/eslint-config/pull/241))
+- Divide global include globs by config type ([#246](https://github.com/JstnMcBrd/eslint-config/pull/246))
 
 ## Added
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Fix typo in CHANGELOG ([#196](https://github.com/JstnMcBrd/eslint-config/pull/196))
+- Fix parsing errors from TypeScript files when `typescript: false` ([#246](https://github.com/JstnMcBrd/eslint-config/pull/246))
 
 ## [2.0.1] - 2025-11-26
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,6 @@ export default function eslintConfig(settings?: Settings): Config[] {
 	return defineConfig(
 		javascript(),
 		(settings?.react ? react(settings) : []),
-		(settings?.typescript ? typescript() : []),
+		(settings?.typescript ? typescript(settings) : []),
 	);
 }

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -7,7 +7,7 @@ import { defineConfig } from 'eslint/config';
 export function javascript(): Config[] {
 	return defineConfig(
 		{
-			files: ['**/*.{m,c,}{js,ts}{x,}'],
+			files: ['**/*.{m,c,}js'],
 		},
 
 		// Report unnecessary eslint-disable comments

--- a/src/react.ts
+++ b/src/react.ts
@@ -6,6 +6,10 @@ import reactHooks from 'eslint-plugin-react-hooks';
 /** @returns ESLint configuration for React */
 export function react(settings: { typescript?: boolean }): Config[] {
 	return defineConfig(
+		{
+			files: [`**/*.{m,c,}{js${settings.typescript ? ',ts' : ''}}x`],
+		},
+
 		// Defaults
 		eslintReact.configs[settings.typescript ? 'strict-type-checked' : 'strict'],
 		reactHooks.configs.flat['recommended-latest'],

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -3,8 +3,12 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 /** @returns ESLint configuration for TypeScript */
-export function typescript(): Config[] {
+export function typescript(settings: { react?: boolean }): Config[] {
 	return defineConfig(
+		{
+			files: [`**/*.{m,c,}{js,ts}${settings.react ? '{x,}' : ''}`],
+		},
+
 		// Ignore the TypeScript output directory
 		globalIgnores(['dist']),
 
@@ -24,9 +28,12 @@ export function typescript(): Config[] {
 		// Additions
 		{
 			rules: {
-				'eqeqeq': 0, // Handled by TypeScript
-				'no-shadow': 0,
+				'eqeqeq': 'off', // Handled by TypeScript
+
+				// https://github.com/eslint/eslint/issues/20776
+				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': 'error',
+
 				'@typescript-eslint/prefer-enum-initializers': 'error',
 				'@typescript-eslint/switch-exhaustiveness-check': 'error',
 			},


### PR DESCRIPTION
Instead of one shared global include glob, different include globs are used based on which language settings are enabled.

Fixes a bug where parsing errors are thrown if `typescript: false` but there are unexpected TypeScript files.